### PR TITLE
Add validation for nested interactive block HTML

### DIFF
--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -221,10 +221,9 @@ class MoodleHtmlElement:
 
     def get_attribute_values(self, attr, exception=None):
         values = []
-        for elem in self.etree_fragments[0].xpath('//*'):
+        for elem in self.etree_fragments[0].xpath(f'//*[@{attr}]'):
             if elem.tag != exception or exception is None:
-                if attr in elem.attrib.keys():
-                    values.append(elem.attrib[attr])
+                values.append(elem.attrib[attr])
         return values
 
     def get_elements_by_name(self, element_name):

--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -231,3 +231,16 @@ class MoodleHtmlElement:
         for child in self.etree_fragments[0].xpath(f'//{element_name}'):
             elems.append(child)
         return elems
+
+    def get_elements_with_string_in_class(self, class_string):
+        # NOTE: This method is only checking if the class string is included
+        #  in the attribute string versus if the specific class is defined
+        xpath_query = f"//*[contains(@class, '{class_string}')]"
+        return self.etree_fragments[0].xpath(xpath_query)
+
+    def element_is_fragment(self, elem):
+        """Checks if the provided element is a fragment"""
+        for fragment in self.etree_fragments:
+            if fragment == elem:
+                return True
+        return False

--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -240,7 +240,4 @@ class MoodleHtmlElement:
 
     def element_is_fragment(self, elem):
         """Checks if the provided element is a fragment"""
-        for fragment in self.etree_fragments:
-            if fragment == elem:
-                return True
-        return False
+        return elem in self.etree_fragments

--- a/mbtools/utils.py
+++ b/mbtools/utils.py
@@ -44,27 +44,3 @@ def parse_question_bank_for_html(mbz_dir, ids=None):
         for item in question.html_elements():
             html.append(item)
     return html
-
-
-def find_external_media_references(activity):
-    """Given an activity find external media file references"""
-    media_references = []
-
-    for html_elem in activity.html_elements():
-        media_references += html_elem.find_references_containing(
-            "amazonaws.com"
-        )
-
-    return media_references
-
-
-def find_moodle_media_references(activity):
-    """Given an activity find moodle media file references"""
-    media_references = []
-
-    for html_elem in activity.html_elements():
-        media_references += html_elem.find_references_containing(
-            "@@PLUGINFILE@@"
-        )
-
-    return media_references

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -34,8 +34,7 @@ IB_ALLOWED_NESTING = ["os-raise-ib-tooltip"]
 
 
 class Violation:
-    def __init__(self, html_string, issue, location, link=None):
-        self.html = html_string
+    def __init__(self, issue, location, link=None):
         self.issue = issue
         self.location = location
         self.link = link
@@ -68,8 +67,7 @@ def find_unnested_violations(html_elements):
     for elem in html_elements:
         if len(elem.unnested_content) > 0:
             for fragment in elem.unnested_content:
-                violations.append(Violation(elem.tostring(),
-                                            UNNESTED_VIOLATION,
+                violations.append(Violation(UNNESTED_VIOLATION,
                                             elem.location,
                                             fragment))
     return violations
@@ -81,8 +79,7 @@ def find_style_violations(html_elements):
         attributes = elem.get_attribute_values("style")
         for attr in attributes:
             if attr not in VALID_STYLES and attr != "":
-                violations.append(Violation(elem.tostring(),
-                                            STYLE_VIOLATION,
+                violations.append(Violation(STYLE_VIOLATION,
                                             elem.location,
                                             attr))
     return violations
@@ -93,16 +90,14 @@ def find_tag_violations(html_elements):
     for elem in html_elements:
         hits = elem.get_elements_by_name("script")
         for _ in hits:
-            violations.append(Violation(elem.tostring(),
-                                        SCRIPT_VIOLATION,
+            violations.append(Violation(SCRIPT_VIOLATION,
                                         elem.location))
         hits = elem.get_elements_by_name("iframe")
         for hit in hits:
             link = hit.attrib['src']
             if len([prefix for prefix in VALID_IFRAME_PREFIXES
                     if(prefix in link)]) == 0:
-                violations.append(Violation(elem.tostring(),
-                                            IFRAME_VIOLATION,
+                violations.append(Violation(IFRAME_VIOLATION,
                                             elem.location,
                                             link))
         hits = elem.get_elements_by_name("a")
@@ -111,8 +106,7 @@ def find_tag_violations(html_elements):
                 link = hit.attrib["href"]
                 if len([prefix for prefix in VALID_HREF_PREFIXES
                         if(prefix in link)]) == 0:
-                    violations.append(Violation(elem.tostring(),
-                                                HREF_VIOLATION,
+                    violations.append(Violation(HREF_VIOLATION,
                                                 elem.location,
                                                 link))
     return violations
@@ -127,13 +121,11 @@ def find_source_violations(html_elements):
                     > 0:    # check if link contains a valid prefix
                 continue
             elif "@@PLUGINFILE@@" in link:
-                violations.append(Violation(elem.tostring(),
-                                            MOODLE_VIOLATION,
+                violations.append(Violation(MOODLE_VIOLATION,
                                             elem.location,
                                             link))
             else:
-                violations.append(Violation(elem.tostring(),
-                                            SOURCE_VIOLATION,
+                violations.append(Violation(SOURCE_VIOLATION,
                                             elem.location,
                                             link))
     return violations
@@ -170,7 +162,6 @@ def find_nested_ib_violations(html_elements):
         for ib in maybe_broken_ibs:
             if not elem.element_is_fragment(ib):
                 violations.append(Violation(
-                    elem.tostring(),
                     NESTED_IB_VIOLATION,
                     elem.location,
                     ib.attrib["class"]

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -30,6 +30,7 @@ VALID_HREF_PREFIXES = ["https://vimeo.com",
 VALID_STYLES = []
 
 INTERACTIVE_BLOCK_CLASS_PREFIX = "os-raise-ib-"
+INTERACTIVE_BLOCK_ALLOWED_NESTING = ["os-raise-ib-tooltip"]
 
 
 class Violation:
@@ -139,7 +140,7 @@ def find_source_violations(html_elements):
 
 
 def find_nested_ib_violations(html_elements):
-    def is_ib_component(elem):
+    def is_unnestable_ib_component(elem):
         """Helper function that looks at the class string for an element
         and determines if it's an actual component. This function avoids
         having to know all of the class names used and instead relies on the
@@ -148,6 +149,8 @@ def find_nested_ib_violations(html_elements):
         """
         class_string = elem.attrib["class"]
         for class_name in class_string.split(" "):
+            if class_name in INTERACTIVE_BLOCK_ALLOWED_NESTING:
+                continue
             ib_name = class_name.split(INTERACTIVE_BLOCK_CLASS_PREFIX)[1]
             if len(ib_name.split("-")) == 1:
                 return True
@@ -160,8 +163,8 @@ def find_nested_ib_violations(html_elements):
             elem.get_elements_with_string_in_class(
                 INTERACTIVE_BLOCK_CLASS_PREFIX
             )
-        actual_ibs = filter(is_ib_component, maybe_ibs)
-        for ib in actual_ibs:
+        maybe_broken_ibs = filter(is_unnestable_ib_component, maybe_ibs)
+        for ib in maybe_broken_ibs:
             if not elem.element_is_fragment(ib):
                 violations.append(Violation(
                     elem.tostring(),

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -147,7 +147,6 @@ def main():
 
     if not output_file.exists():
         output_file.parent.mkdir(parents=True, exist_ok=True)
-        output_file.write_text("[]")
 
     violations = validate_mbz(mbz_path)
     with open(output_file, 'w') as f:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,41 @@
+from lxml import etree
+from mbtools.models import MoodleHtmlElement
+
+
+def test_html_element_get_elements_with_string_in_class():
+    html_content = """
+<div>
+  <p class="foo bar">Element foo bar</p>
+  <p class="bar">Element bar</p>
+  <p class="foobaz">Element foobaz</p>
+</div>
+    """
+    parent = etree.fromstring("<content></content>")
+    parent.text = html_content
+    elem = MoodleHtmlElement(parent, "")
+    foo_elems = elem.get_elements_with_string_in_class("foo")
+    bar_elems = elem.get_elements_with_string_in_class("bar")
+    jedi_elems = elem.get_elements_with_string_in_class("jedi")
+
+    assert set([elem.text for elem in foo_elems]) == \
+        set(["Element foo bar", "Element foobaz"])
+    assert set([elem.text for elem in bar_elems]) == \
+        set(["Element bar", "Element foo bar"])
+    assert len(jedi_elems) == 0
+
+
+def test_html_elements_element_is_fragment():
+    html_content = """
+<div>
+  <p class="bar"></p>
+</div>
+<div class="foo bar"></div>
+    """
+    parent = etree.fromstring("<content></content>")
+    parent.text = html_content
+    elem = MoodleHtmlElement(parent, "")
+    foo_elems = elem.get_elements_with_string_in_class("foo")
+    assert elem.element_is_fragment(foo_elems[0])
+
+    bar_elems = elem.get_elements_with_string_in_class("bar")
+    assert not elem.element_is_fragment(bar_elems[0])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -268,34 +268,6 @@ def test_parse_activity_html_contents(mbz_path):
                 ANSWER2_CONTENT]) == set(parsed_html_content_strings)
 
 
-def test_find_external_media_references(mbz_path):
-    activities = utils.parse_backup_activities(mbz_path)
-    media_references = []
-
-    for act in activities:
-        media_references += utils.find_external_media_references(act)
-
-    assert set([IM_MEDIA_LINK,
-                OSX_MEDIA_LINK,
-                LESSON_ANSW_ILLUSTRATION,
-                QUESTION1_ILLUSTRATION,
-                QUESTION2_ILLUSTRATION,
-                QUESTION3_ILLUSTRATION,
-                ANSWER1_ILLUSTRATION,
-                ANSWER2_ILLUSTRATION]) == set(media_references)
-
-
-def test_find_moodle_media_references(mbz_path):
-    activities = utils.parse_backup_activities(mbz_path)
-    media_references = []
-
-    for act in activities:
-        media_references += utils.find_moodle_media_references(act)
-
-    assert set([MOODLE_VIDEO_FILE, MOODLE_TRACK_FILE]) == \
-        set(media_references)
-
-
 def test_find_question_html(mbz_path):
     html_elements = utils.parse_question_bank_for_html(mbz_path)
     html = []

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -527,3 +527,31 @@ def test_source_violaiton():
     assert style_violations[0].link == "link"
     assert style_violations[0].html == '<img src="link">'
     assert style_violations[0].location == "here"
+
+
+def test_find_nested_ib_violations():
+    valid_content = """
+<div class="os-raise-ib-sometype">
+  <div class="os-raise-ib-sometype-somedata"></div>
+  <div class="os-raise-ib-sometype-otherdata"></div>
+</div>
+<div class="os-raise-ib-anothertype"></div>
+    """
+    bad_content = """
+<div>
+  <div class="os-raise-ib-sometype"></div>
+</div>
+<div class="os-raise-ib-anothertype"></div>
+    """
+    html1 = etree.fromstring("<content></content>")
+    html1.text = valid_content
+    elem1 = MoodleHtmlElement(html1, "loc1")
+    html2 = etree.fromstring("<content></content>")
+    html2.text = bad_content
+    elem2 = MoodleHtmlElement(html2, "loc2")
+    violations = validate_mbz_html.find_nested_ib_violations([elem1, elem2])
+    assert len(violations) == 1
+    assert violations[0].issue == validate_mbz_html.NESTED_IB_VIOLATION
+    assert '<div class="os-raise-ib-sometype"></div>' in violations[0].html
+    assert violations[0].location == "loc2"
+    assert violations[0].link == "os-raise-ib-sometype"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -536,14 +536,18 @@ def test_find_nested_ib_violations():
   <div class="os-raise-ib-sometype-otherdata"></div>
 </div>
 <div class="os-raise-ib-anothertype">
-<p><span class="os-raise-ib-tooltip">vocab word</span></p>
+<p><span class="os-raise-ib-tooltip styleclass">vocab word</span></p>
 </div>
     """
     bad_content = """
 <div>
-  <div class="os-raise-ib-sometype"></div>
+  <div class="os-raise-ib-nestedtype"></div>
 </div>
 <div class="os-raise-ib-anothertype"></div>
+<div class="os-raise-ib-sometype">
+  <div class="os-raise-ib-sometype-somedata"></div>
+  <div class="os-raise-ib-sometype-otherdata"></div>
+</div>
     """
     html1 = etree.fromstring("<content></content>")
     html1.text = valid_content
@@ -554,6 +558,6 @@ def test_find_nested_ib_violations():
     violations = validate_mbz_html.find_nested_ib_violations([elem1, elem2])
     assert len(violations) == 1
     assert violations[0].issue == validate_mbz_html.NESTED_IB_VIOLATION
-    assert '<div class="os-raise-ib-sometype"></div>' in violations[0].html
+    assert '<div class="os-raise-ib-nestedtype"></div>' in violations[0].html
     assert violations[0].location == "loc2"
-    assert violations[0].link == "os-raise-ib-sometype"
+    assert violations[0].link == "os-raise-ib-nestedtype"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -473,7 +473,6 @@ def test_style_violation():
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.STYLE_VIOLATION
     assert style_violations[0].link == "left: allign"
-    assert style_violations[0].html == '<p style="left: allign">html</p>'
     assert style_violations[0].location == "here"
 
 
@@ -486,7 +485,6 @@ def test_href_violaiton():
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.HREF_VIOLATION
     assert style_violations[0].link == "something"
-    assert style_violations[0].html == '<a href="something">html</a>'
     assert style_violations[0].location == "here"
 
 
@@ -499,7 +497,6 @@ def test_script_violaiton():
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.SCRIPT_VIOLATION
     assert style_violations[0].link is None
-    assert style_violations[0].html == '<script>javascript</script>'
     assert style_violations[0].location == "here"
 
 
@@ -512,7 +509,6 @@ def test_iframe_violaiton():
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.IFRAME_VIOLATION
     assert style_violations[0].link == "link"
-    assert style_violations[0].html == '<iframe src="link">something</iframe>'
     assert style_violations[0].location == "here"
 
 
@@ -525,7 +521,6 @@ def test_source_violaiton():
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.SOURCE_VIOLATION
     assert style_violations[0].link == "link"
-    assert style_violations[0].html == '<img src="link">'
     assert style_violations[0].location == "here"
 
 
@@ -558,6 +553,5 @@ def test_find_nested_ib_violations():
     violations = validate_mbz_html.find_nested_ib_violations([elem1, elem2])
     assert len(violations) == 1
     assert violations[0].issue == validate_mbz_html.NESTED_IB_VIOLATION
-    assert '<div class="os-raise-ib-nestedtype"></div>' in violations[0].html
     assert violations[0].location == "loc2"
     assert violations[0].link == "os-raise-ib-nestedtype"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -535,7 +535,9 @@ def test_find_nested_ib_violations():
   <div class="os-raise-ib-sometype-somedata"></div>
   <div class="os-raise-ib-sometype-otherdata"></div>
 </div>
-<div class="os-raise-ib-anothertype"></div>
+<div class="os-raise-ib-anothertype">
+<p><span class="os-raise-ib-tooltip">vocab word</span></p>
+</div>
     """
     bad_content = """
 <div>


### PR DESCRIPTION
This PR includes implementing a validation rule to find interactive blocks that are nested in HTML as well as a few minor / cosmetic cleanup items I noticed.

**NOTE:** To avoid having to update a list of classes in this checker it's written to check for the prefix `os-raise-ib-` and then see if matching elements have a parent without a class with that prefix (this is to filter out things like `os-raise-ib-cta-prompt` vs `os-raise-ib-cta`). It does include an exception list for classes that we allow to be nested since I expect that to not change as often and we'd catch necessary changes in reports where we'd get false positives.