### PR TITLE
Refactor tests that use mbz data and make minor fixes to validator

### DIFF
--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -87,16 +87,21 @@ class MoodleLesson:
             contents = page.xpath("contents")
 
             location = \
-                f'Lesson: {lesson_name} Page_id={page_id}'\
+                f'Lesson: {lesson_name} (page id={page_id}) ' \
                 f'Page Title: {page_title}'
             elements.append(MoodleHtmlElement(contents[0], location))
 
-            if len(page.xpath("answers")) > 0:
-                answer_texts = page.xpath("answers/answer_text")
-                for answer in answer_texts:
-                    answer_location = f'{location} Answer: {answer.text}'
+            for answer in page.xpath("answers/answer"):
+                answer_format = answer.xpath("answerformat")[0]
+                # We need to check the answer format to filter out things
+                # like buttons which are also serialized as answers but are
+                # not HTML
+                if answer_format.text == "1":
+                    answer_text = answer.xpath("answer_text")[0]
+                    answer_location = \
+                        f'{location} (answer id: {answer.attrib["id"]})'
                     elements.append(
-                        MoodleHtmlElement(answer, answer_location))
+                        MoodleHtmlElement(answer_text, answer_location))
         return elements
 
 
@@ -151,7 +156,7 @@ class MoodleQuestion:
     def html_elements(self):
         elements = []
         question_texts = self.etree.xpath(
-                f"//question[@id={self.id}]/questiontext")
+                f"//question[@id={self.id}]//questiontext")
         for question_html in question_texts:
             elements.append(
                 MoodleHtmlElement(question_html, self.location))

--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -65,8 +65,7 @@ class MoodleQuestionBank:
                     questions.append(MoodleQuestion(elems[0],
                                                     ids[i],
                                                     location))
-            if len(questions) != len(ids):
-                raise(NotFoundErr)
+
         return questions
 
 
@@ -202,12 +201,6 @@ class MoodleHtmlElement:
             return {"uuid": content_uuid,
                     "content": content}
         return None
-
-    def find_references_containing(self, src_content):
-        matching_elems = self.etree_fragments[0].xpath(
-            f'//*[contains(@src, "{src_content}")]'
-        )
-        return [el.get("src") for el in matching_elems]
 
     def tostring(self):
         # Pass things through bs4 so we can avoid adding closing tags and

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -46,9 +46,11 @@ class Violation:
         return dict
 
 
-def validate_mbz(mbz_path):
+def validate_mbz(mbz_path, include_questionbank=False):
 
     html_elements = utils.parse_backup_elements(mbz_path)
+    if include_questionbank:
+        html_elements += utils.parse_question_bank_for_html(mbz_path)
 
     violations = []
     violations.extend(find_unnested_violations(html_elements))
@@ -176,15 +178,21 @@ def main():
                         help='relative path to unzipped mbz')
     parser.add_argument('output_file', type=str,
                         help='Path to a file where flags will be outputted')
+    parser.add_argument(
+        '--no-qb',
+        action='store_true',
+        help="Exclude question bank in validation"
+    )
     args = parser.parse_args()
 
     mbz_path = Path(args.mbz_path).resolve(strict=True)
     output_file = Path(args.output_file)
+    include_questionbank = not args.no_qb
 
     if not output_file.exists():
         output_file.parent.mkdir(parents=True, exist_ok=True)
 
-    violations = validate_mbz(mbz_path)
+    violations = validate_mbz(mbz_path, include_questionbank)
     with open(output_file, 'w') as f:
         w = DictWriter(f, ['issue', 'location', 'link'])
         w.writeheader()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,226 @@
+import pytest
+import html
+from string import Template
+
+ANSWER_TEXT_TEMPLATE = Template("""
+<answer id="$id">
+  <answer_text>$content</answer_text>
+</answer>
+""")
+
+LESSON_PAGE_TEMPLATE = Template("""
+<page id="$id">
+  <contents>$content</contents>
+  <answers>
+    $answerdata
+  </answers>
+</page>
+""")
+
+LESSON_TEMPLATE = Template("""
+<?xml version="1.0" encoding="UTF-8"?>
+<activity id="$id" modulename="lesson">
+  <lesson id="$id">
+    <name>$name</name>
+    <pages>
+      $pagedata
+    </pages>
+  </lesson>
+</activity>
+""")
+
+PAGE_TEMPLATE = Template("""
+<?xml version="1.0" encoding="UTF-8"?>
+<activity id="$id" modulename="page">
+  <page id="$id">
+    <name>$name</name>
+    <content>$content</content>
+  </page>
+</activity>
+""")
+
+QUIZ_TEMPLATE = Template("""
+<?xml version="1.0" encoding="UTF-8"?>
+<activity id="$id" modulename="quiz">
+  <quiz id="$id">
+    <name>$name</name>
+    <question_instances>
+      $questiondata
+    </question_instances>
+  </quiz>
+</activity>
+""")
+
+QUIZ_QUESTION_TEMPLATE = Template("""
+<question_instance id="$id">
+  <questionid>$questionid</questionid>
+</question_instance>
+""")
+
+MOODLE_ACTIVITY_TEMPLATE = Template("""
+<activity>
+  <modulename>$activity_type</modulename>
+  <directory>activities/${activity_type}_$id</directory>
+</activity>
+""")
+
+MOODLE_BACKUP_TEMPLATE = Template("""
+<?xml version="1.0" encoding="UTF-8"?>
+<moodle_backup>
+  <contents>
+    <activities>
+      $activitydata
+    </activities>
+  </contents>
+</moodle_backup>
+""")
+
+QUESTION_TEMPLATE = Template("""
+<question id="$id">
+  <questiontext>$content</questiontext>
+  <answers>
+    $answerdata
+  </answers>
+</question>
+""")
+
+QUESTION_BANK_TEMPLATE = Template("""
+<?xml version="1.0" encoding="UTF-8"?>
+<question_categories>
+  <question_category>
+    <questions>
+      $questiondata
+    </questions>
+  </question_category>
+</question_categories>
+""")
+
+
+@pytest.fixture
+def mbz_builder():
+    def _builder(tmp_path, activities, questionbank_questions=[]):
+        activitydata = ""
+        for act in activities:
+            activity_id = act["id"]
+            activity_type = act["activity_type"]
+            activitydata += MOODLE_ACTIVITY_TEMPLATE.substitute(
+                id=activity_id,
+                activity_type=activity_type
+            )
+            activity_dir = \
+                tmp_path / f"activities/{activity_type}_{activity_id}"
+            activity_path = activity_dir / f"{activity_type}.xml"
+            activity_dir.mkdir(parents=True)
+            activity_path.write_text(act["xml_content"].strip())
+
+        questiondata = ""
+        for question in questionbank_questions:
+            answerdata = ""
+            for ans in question.get("answers", []):
+                answerdata += ANSWER_TEXT_TEMPLATE.substitute(
+                    id=ans["id"],
+                    content=html.escape(ans["html_content"])
+                )
+            questiondata += QUESTION_TEMPLATE.substitute(
+                id=question["id"],
+                content=html.escape(question["html_content"]),
+                answerdata=answerdata
+            )
+
+        questionbank_xml = QUESTION_BANK_TEMPLATE.substitute(
+            questiondata=questiondata
+        )
+        (tmp_path / "questions.xml").write_text(questionbank_xml.strip())
+
+        moodle_backup_xml = MOODLE_BACKUP_TEMPLATE.substitute(
+            activitydata=activitydata
+        )
+        (tmp_path / "moodle_backup.xml").write_text(moodle_backup_xml.strip())
+
+    return _builder
+
+
+@pytest.fixture
+def lesson_page_builder():
+    def _builder(id, html_content, answers=[]):
+        answerdata = ""
+        for ans in answers:
+            answerdata += ANSWER_TEXT_TEMPLATE.substitute(
+                id=ans["id"],
+                content=html.escape(ans["html_content"])
+            )
+        return LESSON_PAGE_TEMPLATE.substitute(
+            id=id,
+            content=html.escape(html_content),
+            answerdata=answerdata
+        )
+    return _builder
+
+
+@pytest.fixture
+def lesson_builder(lesson_page_builder):
+    def _builder(id, name, pages=[]):
+        pagedata = ""
+
+        for page in pages:
+            pagedata += lesson_page_builder(
+                id=page["id"],
+                html_content=page["html_content"],
+                answers=page.get("answers", [])
+            )
+
+        lesson_content = LESSON_TEMPLATE.substitute(
+            id=id,
+            name=name,
+            pagedata=pagedata
+        )
+
+        return {
+            "id": id,
+            "activity_type": "lesson",
+            "xml_content": lesson_content
+        }
+    return _builder
+
+
+@pytest.fixture
+def page_builder():
+    def _builder(id, name, html_content):
+        page_content = PAGE_TEMPLATE.substitute(
+            id=id,
+            name=name,
+            content=html.escape(html_content)
+        )
+
+        return {
+            "id": id,
+            "activity_type": "page",
+            "xml_content": page_content
+        }
+
+    return _builder
+
+
+@pytest.fixture
+def quiz_builder():
+    def _builder(id, name, questions=[]):
+        questiondata = ""
+        for question in questions:
+            questiondata += QUIZ_QUESTION_TEMPLATE.substitute(
+                id=question["id"],
+                questionid=question["questionid"]
+            )
+
+        quiz_content = QUIZ_TEMPLATE.substitute(
+            id=id,
+            name=name,
+            questiondata=questiondata
+        )
+
+        return {
+            "id": id,
+            "activity_type": "quiz",
+            "xml_content": quiz_content
+        }
+
+    return _builder

--- a/tests/test_extract_html_content.py
+++ b/tests/test_extract_html_content.py
@@ -1,195 +1,43 @@
-import html
-import pytest
 from pathlib import Path
 from mbtools.extract_html_content import replace_content_tags, main
 import os
-
-IM_MEDIA_LINK = "https://s3.amazonaws.com/im-ims-export/imagename"
-OSX_MEDIA_LINK = "https://osx-int-alg.s3.us-east-1.amazonaws.com/l1/imagename"
-MOODLE_VIDEO_FILE = "@@PLUGINFILE@@/video.mp4"
-MOODLE_TRACK_FILE = "@@PLUGINFILE@@/video.vtt"
-LESSON_ANSW_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/la1"
-QUESTION1_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/q1"
-QUESTION2_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/q2"
-ANSWER1_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/answer1"
-ANSWER2_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/answer2"
+from lxml import etree
 
 
-LESSON1_CONTENT1 = (
-    "<div>"
-    f'<img src="{IM_MEDIA_LINK}">'
-    '<img src="https://validsite/imagename">'
-    "</div>"
-)
+def test_html_files_creation(
+    tmp_path, page_builder, lesson_builder, mbz_builder
+):
+    lesson1_page1_content = "<div><p>Lesson 1 Page 1</p></div>"
+    lesson1_page2_content = "<div><p>Lesson 1 Page 2</p></div>"
+    page2_content = "<div><p>Page 2</p></div>"
 
-LESSON1_CONTENT2 = (
-    "<div>" f'<img src="{OSX_MEDIA_LINK}">' "</div>"
-    "<div><p>More content</p></div>"
-)
-LESSON_ANSWER1 = '<p dir="ltr" style="text-align:' \
-                 ' left;">' "(6, 0)" "<br>" "</p>"
-LESSON_ANSWER2 = (
-    '<p dir="ltr" style="text-align: left;">'
-    '<img alt="Answer Picture" height="71" role="image" '
-    f'src="{LESSON_ANSW_ILLUSTRATION}" title="question" width="101">'
-    "<br>"
-    "</p>"
-)
-PAGE2_CONTENT = (
-    "<div>"
-    '<video controls="true">'
-    f'<source src="{MOODLE_VIDEO_FILE}">'
-    f'<track src="{MOODLE_TRACK_FILE}">'
-    '<track src="https://validsite/video.vtt">'
-    "fallback content"
-    "</video>"
-    "</div>"
-)
+    lesson1 = lesson_builder(
+        id=1,
+        name="Lesson 1",
+        pages=[
+            {
+                "id": 11,
+                "title": "Lesson 1 Page 1",
+                "html_content": lesson1_page1_content
+            },
+            {
+                "id": 12,
+                "title": "Lesson 1 Page 2",
+                "html_content": lesson1_page2_content
+            }
+        ]
+    )
+    page2 = page_builder(id=2, name="Page 2", html_content=page2_content)
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
 
-LESSON1_XML = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="1" modulename="lesson">
-            <lesson id="1">
-                <name>First Lesson: 1.1</name>
-                <pages>
-                    <page id="3">
-                        <title>First Lession: 1.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT1)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER1)}</answer_text>
-                            <answer_text>{html.escape(LESSON_ANSWER2)}</answer_text>
-                        </answers>
-                    </page>
-                    <page id="4">
-                        <title>Second Lession: 2.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT2)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER1)}</answer_text>
-                            <answer_text>{html.escape(LESSON_ANSWER2)}</answer_text>
-                        </answers>
-                    </page>
-                </pages>
-            </lesson>
-        </activity>
-    """.strip()
-PAGE2_XML = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="2" modulename="page">
-            <page id="2">
-                <name>Some Moodle Hosted Content</name>
-                <content>{html.escape(PAGE2_CONTENT)}</content>
-            </page>
-        </activity>
-    """.strip()
-QUESTIONS_XML = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <a></a>
-        """
-BACKUP_XML = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <moodle_backup>
-            <contents>
-            <activities>
-                <activity>
-                    <modulename>lesson</modulename>
-                    <directory>activities/lesson_1</directory>
-                </activity>
-                <activity>
-                    <modulename>page</modulename>
-                    <directory>activities/page_2</directory>
-                </activity>
-
-            </activities>
-            </contents>
-        </moodle_backup>
-    """
-"""
-                <activity>
-                    <modulename>quiz</modulename>
-                    <directory>activities/quiz_3</directory>
-                </activity>
-                """
-
-
-def populate_tags(uuid_content1, uuid_content2, uuid_page):
-    PAGE2_CONTENT_TAG = f'<div class="os-raise-content"' \
-                        f' data-content-id="{uuid_page}"></div>'
-    LESSON1_CONTENT1_TAG = f'<div class="os-raise-content"' \
-                           f' data-content-id="{uuid_content1}"></div>'
-    LESSON1_CONTENT2_TAG = f'<div class="os-raise-content"' \
-                           f' data-content-id="{uuid_content2}"></div>'
-
-    LESSON1_CONTENT_TAGGED = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-<activity id="1" modulename="lesson">
-            <lesson id="1">
-                <name>First Lesson: 1.1</name>
-                <pages>
-                    <page id="3">
-                        <title>First Lession: 1.1 - lesson.xml</title>
-                        <contents>{(html.escape(LESSON1_CONTENT1_TAG,
-                                                quote=False))}</contents>
-                        <answers>
-                            <answer_text>{(html.escape(LESSON_ANSWER1,
-                                                       quote=False))}</answer_text>
-                            <answer_text>{(html.escape(LESSON_ANSWER2,
-                                                       quote=False))}</answer_text>
-                        </answers>
-                    </page>
-                    <page id="4">
-                        <title>Second Lession: 2.1 - lesson.xml</title>
-                        <contents>{(html.escape(LESSON1_CONTENT2_TAG,
-                                                quote=False))}</contents>
-                        <answers>
-                            <answer_text>{(html.escape(LESSON_ANSWER1,
-                                                       quote=False))}</answer_text>
-                            <answer_text>{(html.escape(LESSON_ANSWER2,
-                                                       quote=False))}</answer_text>
-                        </answers>
-                    </page>
-                </pages>
-            </lesson>
-        </activity>""".strip()
-    PAGE2_CONTENT_TAGGED = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-<activity id="2" modulename="page">
-            <page id="2">
-                <name>Some Moodle Hosted Content</name>
-                <content>{(html.escape(PAGE2_CONTENT_TAG,
-                                       quote=False))}</content>
-            </page>
-        </activity>
-    """.strip()
-    return [LESSON1_CONTENT_TAGGED, PAGE2_CONTENT_TAGGED]
-
-
-@pytest.fixture
-def mbz_path(tmp_path):
-    lesson1_content = LESSON1_XML.strip()
-    lesson1_dir = tmp_path / "activities/lesson_1"
-    lesson1_dir.mkdir(parents=True)
-    (lesson1_dir / "lesson.xml").write_text(lesson1_content)
-
-    page2_content = PAGE2_XML.strip()
-    page2_dir = tmp_path / "activities/page_2"
-    page2_dir.mkdir(parents=True)
-    (page2_dir / "page.xml").write_text(page2_content)
-
-    back_xml_content = BACKUP_XML.strip()
-    (tmp_path / "moodle_backup.xml").write_text(back_xml_content)
-
-    questions_xml_content = QUESTIONS_XML.strip()
-    (tmp_path / "questions.xml").write_text(questions_xml_content)
-
-    return tmp_path
-
-
-def test_html_files_creation(mbz_path):
+    mbz_builder(mbz_path, activities=[lesson1, page2])
 
     # Compare file name with files in mbz.
-    html_files_list = replace_content_tags(mbz_path, mbz_path)
+    html_files_list = replace_content_tags(mbz_path, html_path)
     html_file_names_expected = []
-    for file in os.listdir(f"{mbz_path}"):
+    for file in os.listdir(f"{html_path}"):
         if file.endswith(".html"):
             html_file_names_expected.append(Path(file).stem)
 
@@ -199,12 +47,53 @@ def test_html_files_creation(mbz_path):
     assert set(html_file_names_expected) == set(file_names)
 
 
-def test_html_files_content(mbz_path):
+def test_html_files_content(
+    tmp_path, page_builder, lesson_builder, mbz_builder
+):
+    lesson1_page1_content = "<div><p>Lesson 1 Page 1</p></div>"
+    lesson1_page2_content = "<div><p>Lesson 1 Page 2</p></div>"
+    lesson1_page2_answer1_content = "<p>L1 P2 A1</p>"
+    lesson1_page2_answer2_content = "<p>L1 P2 A2</p>"
+    page2_content = "<div><p>Page 2</p></div>"
+
+    lesson1 = lesson_builder(
+        id=1,
+        name="Lesson 1",
+        pages=[
+            {
+                "id": 11,
+                "title": "Lesson 1 Page 1",
+                "html_content": lesson1_page1_content
+            },
+            {
+                "id": 12,
+                "title": "Lesson 1 Page 2",
+                "html_content": lesson1_page2_content,
+                "answers": [
+                    {
+                        "id": 111,
+                        "html_content": lesson1_page2_answer1_content
+                    },
+                    {
+                        "id": 112,
+                        "html_content": lesson1_page2_answer2_content
+                    }
+                ]
+            }
+        ]
+    )
+    page2 = page_builder(id=2, name="Page 2", html_content=page2_content)
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=[lesson1, page2])
+
     # compare expected html file content with files in mbz
-    html_files_list = replace_content_tags(mbz_path, mbz_path)
-    content_expected_in_files = [LESSON1_CONTENT1,
-                                 LESSON1_CONTENT2,
-                                 PAGE2_CONTENT]
+    html_files_list = replace_content_tags(mbz_path, html_path)
+    content_expected_in_files = [lesson1_page1_content,
+                                 lesson1_page2_content,
+                                 page2_content]
 
     file_contents = []
     for file in html_files_list:
@@ -213,9 +102,38 @@ def test_html_files_content(mbz_path):
     assert set(content_expected_in_files) == set(file_contents)
 
 
-def test_xml_content_changed(mbz_path):
+def test_xml_content_changed(
+    tmp_path, page_builder, lesson_builder, mbz_builder
+):
+    lesson1_page1_content = "<div><p>Lesson 1 Page 1</p></div>"
+    lesson1_page2_content = "<div><p>Lesson 1 Page 2</p></div>"
+    page2_content = "<div><p>Page 2</p></div>"
+
+    lesson1 = lesson_builder(
+        id=1,
+        name="Lesson 1",
+        pages=[
+            {
+                "id": 11,
+                "title": "Lesson 1 Page 1",
+                "html_content": lesson1_page1_content
+            },
+            {
+                "id": 12,
+                "title": "Lesson 1 Page 2",
+                "html_content": lesson1_page2_content
+            }
+        ]
+    )
+    page2 = page_builder(id=2, name="Page 2", html_content=page2_content)
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=[lesson1, page2])
+
     # Compare file content with files in mbz
-    html_files_list = replace_content_tags(mbz_path, mbz_path)
+    html_files_list = replace_content_tags(mbz_path, html_path)
 
     file_names = []
     for file in html_files_list:
@@ -223,28 +141,56 @@ def test_xml_content_changed(mbz_path):
 
     tags = []
     for name in file_names:
-        tags.append(html.escape(f'<div class="os-raise-content" '
-                                f'data-content-id="{name}"></div>',
-                                quote=False))
+        tags.append(
+            f'<div class="os-raise-content" data-content-id="{name}"></div>'
+        )
 
-    correct_content = populate_tags(file_names[0],
-                                    file_names[1], file_names[2])
-    correct_content = "".join(correct_content)
-    for tag in tags:
-        assert tag in correct_content
+    updated_lesson_etree = etree.parse(
+        f"{mbz_path}/activities/lesson_1/lesson.xml"
+    )
+
+    updated_lesson1_page1_content = updated_lesson_etree.xpath(
+        "//page[@id=11]/contents"
+    )[0].text
+
+    assert updated_lesson1_page1_content in tags
+
+    updated_lesson1_page2_content = updated_lesson_etree.xpath(
+        "//page[@id=12]/contents"
+    )[0].text
+
+    assert updated_lesson1_page2_content in tags
+
+    updated_page_etree = etree.parse(f"{mbz_path}/activities/page_2/page.xml")
+
+    updated_page2_content = updated_page_etree.xpath("//page/content")[0].text
+
+    assert updated_page2_content in tags
 
 
-def test_ignore_extracted_content(mbz_path):
+def test_ignore_extracted_content(tmp_path, page_builder, mbz_builder):
+    pages = []
+    for indx in range(3):
+        pages.append(page_builder(
+            id=indx,
+            name="Page",
+            html_content="<div><p>Page</p></div>"
+        ))
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=pages)
 
     # Extracted tags should not be extracted again.
-    html_files_list_first_run = replace_content_tags(mbz_path, mbz_path)
+    html_files_list_first_run = replace_content_tags(mbz_path, html_path)
     html_files_inmbz_first_run = []
 
     for file in os.listdir(f"{mbz_path}"):
         if file.endswith(".html"):
             html_files_inmbz_first_run.append(Path(file).stem)
 
-    html_files_list_second_run = replace_content_tags(mbz_path, mbz_path)
+    html_files_list_second_run = replace_content_tags(mbz_path, html_path)
     html_files_inmbz_second_run = []
 
     for file in os.listdir(f"{mbz_path}"):
@@ -260,44 +206,129 @@ def test_ignore_extracted_content(mbz_path):
     assert(len(html_files_list_second_run) == 0)
 
 
-def test_main_no_filter(mbz_path, mocker):
+def test_main_no_filter(
+    tmp_path, page_builder, lesson_builder, mbz_builder, mocker
+):
     # Test for main function called by the CLI.
     # No filter args should default to extract page and lesson content.
+    activities = []
+    for indx in range(1):
+        activities.append(page_builder(
+            id=indx,
+            name="Page",
+            html_content="<div><p>Page</p></div>"
+        ))
+
+    for indx in range(2):
+        activities.append(lesson_builder(
+            id=indx,
+            name="Lesson",
+            pages=[
+                {
+                    "id": indx,
+                    "title": "Lesson Page",
+                    "html_content": "<div><p>Lesson page</p></div>"
+                }
+            ]
+        ))
+
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=activities)
     mocker.patch(
         "sys.argv",
-        ["", f"{mbz_path}", f"{mbz_path}"]
+        ["", f"{mbz_path}", f"{html_path}"]
     )
     main()
     html_files_in_mbz = []
-    for file in os.listdir(f"{mbz_path}"):
+    for file in os.listdir(f"{html_path}"):
         if file.endswith(".html"):
             html_files_in_mbz.append(Path(file).stem)
     assert len(html_files_in_mbz) == 3
 
 
-def test_main_lesson_filter(mbz_path, mocker):
+def test_main_lesson_filter(
+    tmp_path, page_builder, lesson_builder, mbz_builder, mocker
+):
     # Test for main function called by the CLI with lesson filter.
+    activities = []
+    for indx in range(1):
+        activities.append(page_builder(
+            id=indx,
+            name="Page",
+            html_content="<div><p>Page</p></div>"
+        ))
+
+    for indx in range(2):
+        activities.append(lesson_builder(
+            id=indx,
+            name="Lesson",
+            pages=[
+                {
+                    "id": indx,
+                    "title": "Lesson Page",
+                    "html_content": "<div><p>Lesson page</p></div>"
+                }
+            ]
+        ))
+
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=activities)
+
     mocker.patch(
         "sys.argv",
-        ["", f"{mbz_path}", f"{mbz_path}", "-filter", "lesson"]
+        ["", f"{mbz_path}", f"{html_path}", "-filter", "lesson"]
     )
     main()
     html_files_in_mbz = []
-    for file in os.listdir(f"{mbz_path}"):
+    for file in os.listdir(f"{html_path}"):
         if file.endswith(".html"):
             html_files_in_mbz.append(Path(file).stem)
     assert len(html_files_in_mbz) == 2
 
 
-def test_main_page_filter(mbz_path, mocker):
+def test_main_page_filter(
+    tmp_path, page_builder, lesson_builder, mbz_builder, mocker
+):
     # Test for main function called by the CLI with page filter.
+    activities = []
+    for indx in range(1):
+        activities.append(page_builder(
+            id=indx,
+            name="Page",
+            html_content="<div><p>Page</p></div>"
+        ))
+
+    for indx in range(2):
+        activities.append(lesson_builder(
+            id=indx,
+            name="Lesson",
+            pages=[
+                {
+                    "id": indx,
+                    "title": "Lesson Page",
+                    "html_content": "<div><p>Lesson page</p></div>"
+                }
+            ]
+        ))
+
+    mbz_path = tmp_path / "mbz"
+    html_path = tmp_path / "html"
+    html_path.mkdir()
+
+    mbz_builder(mbz_path, activities=activities)
     mocker.patch(
         "sys.argv",
-        ["", f"{mbz_path}", f"{mbz_path}", "-filter", "page"]
+        ["", f"{mbz_path}", f"{html_path}", "-filter", "page"]
     )
     main()
     html_files_in_mbz = []
-    for file in os.listdir(f"{mbz_path}"):
+    for file in os.listdir(f"{html_path}"):
         if file.endswith(".html"):
             html_files_in_mbz.append(Path(file).stem)
     assert len(html_files_in_mbz) == 1

--- a/tests/test_remove_styles.py
+++ b/tests/test_remove_styles.py
@@ -1,267 +1,42 @@
-import pytest
-import html
 from mbtools import remove_styles
 from lxml import etree
 from mbtools.models import MoodleHtmlElement
 
-IM_MEDIA_LINK = "https://s3.amazonaws.com/im-ims-export/imagename"
-OSX_MEDIA_LINK = "https://s3.amazonaws.com/im-ims-export/l1/imagename"
-MOODLE_VIDEO_FILE = "@@PLUGINFILE@@/video.mp4"
-MOODLE_TRACK_FILE = "@@PLUGINFILE@@/video.vtt"
-LESSON_ANSW_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/la1"
-QUESTION1_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/q1"
-QUESTION2_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/q2"
-QUESTION3_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/q3"
-ANSWER1_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/answer1"
-ANSWER2_ILLUSTRATION = "https://s3.amazonaws.com/im-ims-export/answer2"
-ADDITIONAL_MEDIA = "https://wikipedia.com/brazil/image1"
-ADDITIONAL_MEDIA2 = "https://wikipedia.com/brazil/image2"
-ADDITIONAL_MEDIA3 = "https://wikipedia.com/brazil/image3"
-ADDITIONAL_MEDIA4 = "https://wikipedia.com/brazil/image4"
 
-LESSON1_CONTENT1 = (
-    '<div>'
-    '<div>'
-    f'<img src="{IM_MEDIA_LINK}">'
-    f'<img src="{ADDITIONAL_MEDIA}">'
-    '</div>'
-    '</div>'
-)
-LESSON1_CONTENT2 = (
-    '<div>'
-    f'<img src="{OSX_MEDIA_LINK}">'
-    '</div>'
-)
-LESSON_ANSWER1 = (
-    '<p dir="ltr" style="text-align: left; color=blue; font-size: 10px">'
-    '(6, 0)'
-    '<br>'
-    '</p>'
-)
-LESSON_ANSWER2 = (
-    '<p dir="ltr">'
-    '<img alt="Answer Picture" height="71" role="image" '
-    f'src="{LESSON_ANSW_ILLUSTRATION}" title="question" width="101">'
-    '<br>'
-    '</p>'
-)
-LESSON_ANSWER3 = (
-    '<p dir="ltr" style="text-align: left; color= red;">'
-    '(3, 2)'
-    '<br>'
-    '</p>'
-)
-PAGE2_CONTENT = (
-    '<div>'
-    '<video style="border: 5px" :controls="true">'
-    f'<source src="{MOODLE_VIDEO_FILE}">'
-    f'<track src="{MOODLE_TRACK_FILE}">'
-    f'<track src="{ADDITIONAL_MEDIA2}">'
-    'fallback content'
-    '</video>'
-    f'<a href="{ADDITIONAL_MEDIA3}">'
-    '</a>'
-    '<script>var variable=0'
-    '</script>'
-    '</div>'
-)
-QUESTION1_CONTENT = (
-    '<div>'
-    '<p>'
-    'What is the capital of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION1_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<p>'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-QUESTION2_CONTENT = (
-    '<div>'
-    '<p>'
-    'Write 10 pages on the colonization of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION2_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<p style="border: 5px">'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-QUESTION3_CONTENT = (
-    '<div>'
-    '<p>'
-    'Draw and submit a picture of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION3_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<script>var variable=0'
-    '</script>'
-    '<p style="border: 5px">'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-ANSWER1_CONTENT = (
-    '<div>'
-    '<p>'
-    'Brasilia'
-    '</p>'
-    '<img alt="A Picture of Brasilia" height="71" role="image" '
-    f'src="{ANSWER1_ILLUSTRATION}" title="answer1" width="101">'
-    f'<iframe src="{ADDITIONAL_MEDIA4}">A SINGLE IFRAME'
-    '</iframe>'
-    '</div>'
-)
-ANSWER2_CONTENT = (
-    '<div>'
-    '<p style="border: 5px">'
-    'Rio de Janiero'
-    '</p>'
-    '<img alt="A picture of Rio De Janiero" height="71" role="image" '
-    f'src="{ANSWER2_ILLUSTRATION}" title="answer2" width="101">'
-    '</div>'
-)
+def test_remove_styles_from_main(
+    tmp_path, mbz_builder, page_builder, lesson_builder, mocker
+):
+    content_with_styles = \
+        '<p style="text-align: left; color=blue; font-size: 10px">Text</p>'
+    page1 = page_builder(2, "Page", content_with_styles)
+    lesson2 = lesson_builder(
+        id=1,
+        name="Lesson",
+        pages=[
+            {
+                "id": 21,
+                "title": "Lesson 1 Page 1",
+                "html_content": content_with_styles
+            },
+            {
+                "id": 22,
+                "title": "Lesson 1 Page 2",
+                "html_content": content_with_styles,
+                "answers": [
+                    {
+                        "id": 221,
+                        "html_content": content_with_styles
+                    },
+                    {
+                        "id": 222,
+                        "html_content": content_with_styles
+                    }
+                ]
+            }
+        ]
+    )
+    mbz_builder(tmp_path, [page1, lesson2])
 
-
-@pytest.fixture
-def mbz_path(tmp_path):
-    back_xml_content = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <moodle_backup>
-            <contents>
-            <activities>
-                <activity>
-                    <modulename>lesson</modulename>
-                    <title>First Lesson: 1.1</title>
-                    <directory>activities/lesson_1</directory>
-                </activity>
-                <activity>
-                    <modulename>page</modulename>
-                    <title>Second Lesson: 2.1</title>
-                    <directory>activities/page_2</directory>
-                </activity>
-                <activity>
-                    <modulename>quiz</modulename>
-                    <title>Third Lesson: 3.1</title>
-                    <directory>activities/quiz_3</directory>
-                </activity>
-            </activities>
-            </contents>
-        </moodle_backup>
-    """.strip()
-    (tmp_path / "moodle_backup.xml").write_text(back_xml_content)
-
-    lesson1_content = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="1" modulename="lesson">
-            <lesson id="1">
-                <name>First Lesson: 1.1</name>
-                <pages>
-                    <page id="3">
-                        <title>First Lession: 1.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT1)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER1)}</answer_text>
-                            <answer_text>{html.escape(LESSON_ANSWER2)}</answer_text>
-                        </answers>
-                    </page>
-                    <page id="4">
-                        <title>Second Lession: 2.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT2)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER3)}</answer_text>
-                        </answers>
-                    </page>
-                </pages>
-            </lesson>
-        </activity>
-    """.strip()
-    lesson1_dir = tmp_path / "activities/lesson_1"
-    lesson1_dir.mkdir(parents=True)
-    (lesson1_dir / "lesson.xml").write_text(lesson1_content)
-
-    page2_content = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="2" modulename="page">
-            <page id="2">
-                <name>Page 2 - A Special Activity</name>
-                <content>{html.escape(PAGE2_CONTENT)}</content>
-            </page>
-        </activity>
-    """.strip()
-    page2_dir = tmp_path / "activities/page_2"
-    page2_dir.mkdir(parents=True)
-    (page2_dir / "page.xml").write_text(page2_content)
-
-    quiz3_content = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="3" modulename="quiz">
-            <quiz id="1">
-                <name>Fist Example Quiz</name>
-                <question_instances>
-                    <question_instance id="1">
-                        <questionid>1</questionid>
-                    </question_instance>
-                    <question_instance id ="2">
-                        <questionid>2</questionid>
-                    </question_instance>
-                </question_instances>
-            </quiz>
-            <quiz id="2">
-                <name>Second Example Quiz</name>
-                <question_instances>
-                    <question_instance id="3">
-                        <questionid>3</questionid>
-                    </question_instance>
-                </question_instances>
-            </quiz>
-        </activity>
-    """.strip()
-    quiz3_dir = tmp_path / "activities/quiz_3"
-    quiz3_dir.mkdir(parents=True)
-    (quiz3_dir / "quiz.xml").write_text(quiz3_content)
-
-    question_content = f"""
-    <?xml version="1.0" encoding="UTF-8"?>
-    <question_categories>
-        <question_category id="1">
-            <name>Quiz Bank 'Algebra1.1 Check Your Readiness'</name>
-            <questions>
-                <question id="1">
-                <questiontext>{html.escape(QUESTION1_CONTENT)}</questiontext>
-                <answers>
-                    <answer id="1">
-                    <answertext>{html.escape(ANSWER1_CONTENT)}</answertext>
-                    </answer>
-                    <answer id="2">
-                    <answertext>{html.escape(ANSWER2_CONTENT)}</answertext>
-                    </answer>
-                </answers>
-                </question>
-                <question id="2">
-                <questiontext>{html.escape(QUESTION2_CONTENT)}</questiontext>
-                </question>
-                <question id="3">
-                <questiontext>{html.escape(QUESTION3_CONTENT)}</questiontext>
-                </question>
-            </questions>
-        </question_category>
-    </question_categories>
-    """.strip()
-    (tmp_path / "questions.xml").write_text(question_content)
-
-    return tmp_path
-
-
-def test_remove_styles_from_main(mbz_path, tmp_path, mocker):
     mocker.patch(
         "sys.argv",
         ["", f"{tmp_path}"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,254 +1,105 @@
 from xml.dom import NotFoundErr
 import pytest
-import html
 from mbtools import utils
 
 
-IM_MEDIA_LINK = "https://s3.amazonaws.com/im-ims-export/imagename"
-OSX_MEDIA_LINK = "https://osx-int-alg.s3.us-east-1.amazonaws.com/l1/imagename"
-MOODLE_VIDEO_FILE = "@@PLUGINFILE@@/video.mp4"
-MOODLE_TRACK_FILE = "@@PLUGINFILE@@/video.vtt"
-LESSON_ANSW_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/la1"
-QUESTION1_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/q1"
-QUESTION2_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/q2"
-QUESTION3_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/q3"
-ANSWER1_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/answer1"
-ANSWER2_ILLUSTRATION = "https://osx-int-alg.s3.us-east-1.amazonaws.com/answer2"
-
-LESSON1_CONTENT1 = (
-    '<div>'
-    f'<img src="{IM_MEDIA_LINK}">'
-    '<img src="https://validsite/imagename">'
-    '</div>'
-)
-LESSON1_CONTENT2 = (
-    '<div>'
-    f'<img src="{OSX_MEDIA_LINK}">'
-    '</div>'
-)
-LESSON_ANSWER1 = (
-    '<p dir="ltr" style="text-align: left;">'
-    '(6, 0)'
-    '<br>'
-    '</p>'
-)
-LESSON_ANSWER2 = (
-    '<p dir="ltr" style="text-align: left;">'
-    '<img alt="Answer Picture" height="71" role="image" '
-    f'src="{LESSON_ANSW_ILLUSTRATION}" title="question" width="101">'
-    '<br>'
-    '</p>'
-)
-PAGE2_CONTENT = (
-    '<div>'
-    '<video controls="true">'
-    f'<source src="{MOODLE_VIDEO_FILE}">'
-    f'<track src="{MOODLE_TRACK_FILE}">'
-    '<track src="https://validsite/video.vtt">'
-    'fallback content'
-    '</video>'
-    '</div>'
-)
-QUESTION1_CONTENT = (
-    '<div>'
-    '<p>'
-    'What is the capital of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION1_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<p>'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-QUESTION2_CONTENT = (
-    '<div>'
-    '<p>'
-    'Write 10 pages on the colonization of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION2_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<p>'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-QUESTION3_CONTENT = (
-    '<div>'
-    '<p>'
-    'Draw and submit a picture of Brazil'
-    '</p>'
-    '<div>'
-    '<img alt="A picture of a map of Brazil" height="71" role="image" '
-    f'src="{QUESTION3_ILLUSTRATION}" title="question" width="202">'
-    '</div>'
-    '<p>'
-    'Select <strong>all</strong> statements that must be true.'
-    '</p>'
-    '</div>'
-)
-ANSWER1_CONTENT = (
-    '<div>'
-    '<p>'
-    'Brasilia'
-    '</p>'
-    '<img alt="A Picture of Brasilia" height="71" role="image" '
-    f'src="{ANSWER1_ILLUSTRATION}" title="answer1" width="101">'
-    '</div>'
-)
-ANSWER2_CONTENT = (
-    '<div>'
-    '<p>'
-    'Rio de Janiero'
-    '</p>'
-    '<img alt="A picture of Rio De Janiero" height="71" role="image" '
-    f'src="{ANSWER2_ILLUSTRATION}" title="answer2" width="101">'
-    '</div>'
-)
-
-
-@pytest.fixture
-def mbz_path(tmp_path):
-    back_xml_content = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <moodle_backup>
-            <contents>
-            <activities>
-                <activity>
-                    <modulename>lesson</modulename>
-                    <title>First Lesson: 1.1</title>
-                    <directory>activities/lesson_1</directory>
-                </activity>
-                <activity>
-                    <modulename>page</modulename>
-                    <title>Second Lesson: 2.1</title>
-                    <directory>activities/page_2</directory>
-                </activity>
-                <activity>
-                    <modulename>quiz</modulename>
-                    <title>Third Lesson: 3.1</title>
-                    <directory>activities/quiz_3</directory>
-                </activity>
-            </activities>
-            </contents>
-        </moodle_backup>
-    """.strip()
-    (tmp_path / "moodle_backup.xml").write_text(back_xml_content)
-
-    lesson1_content = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="1" modulename="lesson">
-            <lesson id="1">
-                <name>First Lesson: 1.1</name>
-                <pages>
-                    <page id="3">
-                        <title>First Lession: 1.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT1)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER1)}</answer_text>
-                            <answer_text>{html.escape(LESSON_ANSWER2)}</answer_text>
-                        </answers>
-                    </page>
-                    <page id="4">
-                        <title>Second Lession: 2.1 - lesson.xml</title>
-                        <contents>{html.escape(LESSON1_CONTENT2)}</contents>
-                        <answers>
-                            <answer_text>{html.escape(LESSON_ANSWER1)}</answer_text>
-                            <answer_text>{html.escape(LESSON_ANSWER2)}</answer_text>
-                        </answers>
-                    </page>
-                </pages>
-            </lesson>
-        </activity>
-    """.strip()
-    lesson1_dir = tmp_path / "activities/lesson_1"
-    lesson1_dir.mkdir(parents=True)
-    (lesson1_dir / "lesson.xml").write_text(lesson1_content)
-
-    page2_content = f"""
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="2" modulename="page">
-            <page id="2">
-                <name>Some Moodle Hosted Content</name>
-                <content>{html.escape(PAGE2_CONTENT)}</content>
-            </page>
-        </activity>
-    """.strip()
-    page2_dir = tmp_path / "activities/page_2"
-    page2_dir.mkdir(parents=True)
-    (page2_dir / "page.xml").write_text(page2_content)
-
-    quiz3_content = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <activity id="3" modulename="quiz">
-            <quiz id="1">
-                <name>Fist Example Quiz</name>
-                <question_instances>
-                    <question_instance id="1">
-                        <questionid>1</questionid>
-                    </question_instance>
-                    <question_instance id ="2">
-                        <questionid>2</questionid>
-                    </question_instance>
-                </question_instances>
-            </quiz>
-            <quiz id="2">
-                <name>Second Example Quiz</name>
-                <question_instances>
-                    <question_instance id="3">
-                        <questionid>3</questionid>
-                    </question_instance>
-                </question_instances>
-            </quiz>
-        </activity>
-    """.strip()
-    quiz3_dir = tmp_path / "activities/quiz_3"
-    quiz3_dir.mkdir(parents=True)
-    (quiz3_dir / "quiz.xml").write_text(quiz3_content)
-
-    question_content = f"""
-    <?xml version="1.0" encoding="UTF-8"?>
-    <question_categories>
-        <question_category id="1">
-            <name>Quiz Bank 'Algebra1.1 Check Your Readiness'</name>
-            <questions>
-                <question id="1">
-                <questiontext>{html.escape(QUESTION1_CONTENT)}</questiontext>
-                <answers>
-                    <answer id="1">
-                    <answertext>{html.escape(ANSWER1_CONTENT)}</answertext>
-                    </answer>
-                    <answer id="2">
-                    <answertext>{html.escape(ANSWER2_CONTENT)}</answertext>
-                    </answer>
-                </answers>
-                </question>
-                <question id="2">
-                <questiontext>{html.escape(QUESTION2_CONTENT)}</questiontext>
-                </question>
-                <question id="3">
-                <questiontext>{html.escape(QUESTION3_CONTENT)}</questiontext>
-                </question>
-            </questions>
-        </question_category>
-    </question_categories>
-    """.strip()
-    (tmp_path / "questions.xml").write_text(question_content)
-
-    return tmp_path
-
-
-def test_parse_backup_activities(mbz_path):
-    activities = utils.parse_backup_activities(mbz_path)
+def test_parse_backup_activities(
+    tmp_path, mbz_builder, page_builder, lesson_builder, quiz_builder
+):
+    page = page_builder(id=1, name="Page 1", html_content="<p>page 1</p>")
+    lesson = lesson_builder(id=2, name="Lesson 2")
+    quiz = quiz_builder(id=3, name="Quiz 3")
+    mbz_builder(tmp_path, [page, lesson, quiz])
+    activities = utils.parse_backup_activities(tmp_path)
     assert len(activities) == 3
 
 
-def test_parse_activity_html_contents(mbz_path):
-    activities = utils.parse_backup_activities(mbz_path)
+def test_parse_activity_html_contents(
+    tmp_path, mbz_builder, page_builder, lesson_builder, quiz_builder
+):
+    lesson1_page1_content = "<div><p>Lesson 1 Page 1</p></div>"
+    lesson1_page2_content = "<div><p>Lesson 1 Page 2</p></div>"
+    lesson1_page2_answer1_content = "<p>L1 P2 A1</p>"
+    lesson1_page2_answer2_content = "<p>L1 P2 A2</p>"
+    page2_content = "<div><p>Page 2</p></div>"
+    qb_question1_content = "<p>Question 1</p>"
+    qb_question1_answer1_content = "<p>answer 1</p>"
+    qb_question1_answer2_content = "<p>answer 2</p>"
+    qb_question2_content = "<p>Question 2</p>"
+    qb_question3_content = "<p>Question 3</p>"
+
+    lesson1 = lesson_builder(
+        id=1,
+        name="Lesson 1",
+        pages=[
+            {
+                "id": 11,
+                "title": "Lesson 1 Page 1",
+                "html_content": lesson1_page1_content
+            },
+            {
+                "id": 12,
+                "title": "Lesson 1 Page 2",
+                "html_content": lesson1_page2_content,
+                "answers": [
+                    {
+                        "id": 111,
+                        "html_content": lesson1_page2_answer1_content
+                    },
+                    {
+                        "id": 112,
+                        "html_content": lesson1_page2_answer2_content
+                    }
+                ]
+            }
+        ]
+    )
+    page2 = page_builder(id=2, name="Page 2", html_content=page2_content)
+    quiz3 = quiz_builder(
+        id=3,
+        name="Quiz 3",
+        questions=[
+            {
+                "id": 31,
+                "questionid": 1
+            },
+            {
+                "id": 32,
+                "questionid": 2
+            }
+        ]
+    )
+
+    mbz_builder(
+        tmp_path,
+        activities=[lesson1, page2, quiz3],
+        questionbank_questions=[
+            {
+                "id": 1,
+                "html_content": qb_question1_content,
+                "answers": [
+                    {
+                        "id": 11,
+                        "html_content": qb_question1_answer1_content
+                    },
+                    {
+                        "id": 12,
+                        "html_content": qb_question1_answer2_content
+                    }
+                ]
+            },
+            {
+                "id": 2,
+                "html_content": qb_question2_content
+            },
+            {
+                "id": 3,
+                "html_content": qb_question3_content
+            }
+        ]
+    )
+
+    activities = utils.parse_backup_activities(tmp_path)
 
     parsed_html_content_strings = []
     for act in activities:
@@ -256,42 +107,133 @@ def test_parse_activity_html_contents(mbz_path):
             parsed_html_content_strings.append(
                 html_elem.tostring()
             )
-    assert set([LESSON1_CONTENT1,
-                LESSON1_CONTENT2,
-                LESSON_ANSWER1,
-                LESSON_ANSWER2,
-                PAGE2_CONTENT,
-                QUESTION1_CONTENT,
-                QUESTION2_CONTENT,
-                QUESTION3_CONTENT,
-                ANSWER1_CONTENT,
-                ANSWER2_CONTENT]) == set(parsed_html_content_strings)
+    assert set([
+        lesson1_page1_content,
+        lesson1_page2_content,
+        lesson1_page2_answer1_content,
+        lesson1_page2_answer2_content,
+        page2_content,
+        qb_question1_content,
+        qb_question1_answer1_content,
+        qb_question1_answer2_content,
+        qb_question2_content,
+    ]) == set(parsed_html_content_strings)
 
 
-def test_find_question_html(mbz_path):
-    html_elements = utils.parse_question_bank_for_html(mbz_path)
+def test_find_question_html(tmp_path, mbz_builder):
+    qb_question1_content = "<p>Question 1</p>"
+    qb_question1_answer1_content = "<p>answer 1</p>"
+    qb_question1_answer2_content = "<p>answer 2</p>"
+    qb_question2_content = "<p>Question 2</p>"
+    qb_question3_content = "<p>Question 3</p>"
+    qb_question3_match1_question = "<p>Match 1</p>"
+    qb_question3_match2_question = "<p>Match 1</p>"
+
+    mbz_builder(
+        tmp_path,
+        activities=[],
+        questionbank_questions=[
+            {
+                "id": 1,
+                "html_content": qb_question1_content,
+                "answers": [
+                    {
+                        "id": 11,
+                        "html_content": qb_question1_answer1_content
+                    },
+                    {
+                        "id": 12,
+                        "html_content": qb_question1_answer2_content
+                    }
+                ]
+            },
+            {
+                "id": 2,
+                "html_content": qb_question2_content
+            },
+            {
+                "id": 3,
+                "html_content": qb_question3_content,
+                "matches": [
+                    {
+                        "id": 1,
+                        "answer_content": "Some non-HTML content",
+                        "question_html_content": qb_question3_match1_question
+                    },
+                    {
+                        "id": 2,
+                        "answer_content": "Some non-HTML content",
+                        "question_html_content": qb_question3_match2_question
+                    }
+                ]
+            }
+        ]
+    )
+    html_elements = utils.parse_question_bank_for_html(tmp_path)
     html = []
     for elem in html_elements:
         html.append(elem.tostring())
-    assert len(html) == 5
-    assert set([QUESTION1_CONTENT,
-                QUESTION2_CONTENT,
-                QUESTION3_CONTENT,
-                ANSWER1_CONTENT,
-                ANSWER2_CONTENT]) == set(html)
+    assert len(html) == 7
+    assert set([
+        qb_question1_content,
+        qb_question1_answer1_content,
+        qb_question1_answer2_content,
+        qb_question2_content,
+        qb_question3_content,
+        qb_question3_match1_question,
+        qb_question3_match2_question
+    ]) == set(html)
 
 
-def test_find_questions_by_id(mbz_path):
+def test_find_questions_by_id(tmp_path, mbz_builder):
+    qb_question1_content = "<p>Question 1</p>"
+    qb_question1_answer1_content = "<p>answer 1</p>"
+    qb_question1_answer2_content = "<p>answer 2</p>"
+    qb_question2_content = "<p>Question 2</p>"
+    qb_question3_content = "<p>Question 3</p>"
+
+    mbz_builder(
+        tmp_path,
+        activities=[],
+        questionbank_questions=[
+            {
+                "id": 1,
+                "html_content": qb_question1_content,
+                "answers": [
+                    {
+                        "id": 11,
+                        "html_content": qb_question1_answer1_content
+                    },
+                    {
+                        "id": 12,
+                        "html_content": qb_question1_answer2_content
+                    }
+                ]
+            },
+            {
+                "id": 2,
+                "html_content": qb_question2_content
+            },
+            {
+                "id": 3,
+                "html_content": qb_question3_content
+            }
+        ]
+    )
     ids = ["1"]
-    html_elements = utils.parse_question_bank_for_html(mbz_path, ids)
+    html_elements = utils.parse_question_bank_for_html(tmp_path, ids)
     html = []
     for elem in html_elements:
         html.append(elem.tostring())
     assert len(html) == 3
-    assert set([QUESTION1_CONTENT,
-                ANSWER1_CONTENT,
-                ANSWER2_CONTENT]) == set(html)
+    assert set([qb_question1_content,
+                qb_question1_answer1_content,
+                qb_question1_answer2_content]) == set(html)
 
     with pytest.raises(NotFoundErr):
         ids = ["9"]
-        html = utils.parse_question_bank_for_html(mbz_path, ids)
+        html = utils.parse_question_bank_for_html(tmp_path, ids)
+
+    with pytest.raises(NotFoundErr):
+        ids = ["1", "9"]
+        html = utils.parse_question_bank_for_html(tmp_path, ids)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -555,3 +555,22 @@ def test_find_nested_ib_violations():
     assert violations[0].issue == validate_mbz_html.NESTED_IB_VIOLATION
     assert violations[0].location == "loc2"
     assert violations[0].link == "os-raise-ib-nestedtype"
+
+
+def test_find_nested_ib_violations_mbz(
+    tmp_path, mbz_builder, page_builder, mocker
+):
+    bad_content = '<div><div class="os-raise-ib-nestedtype"></div></div>'
+    page1 = page_builder(1, "Page", bad_content)
+    mbz_builder(tmp_path / "mbz", [page1])
+
+    mocker.patch(
+        "sys.argv",
+        ["", f"{tmp_path}/mbz", f"{tmp_path}/test_output.csv"]
+    )
+
+    validate_mbz_html.main()
+
+    reader = csv.DictReader(open(tmp_path / "test_output.csv"))
+    errors = [row for row in reader]
+    assert len(errors) == 1


### PR DESCRIPTION
A few notes on this PR:

* It extends the work from [this PR](https://github.com/openstax/raise-mbtools/pull/17) and hence until that is merged will look larger than it is (this PR should therefore only be merged after that).
* While it was originally focused on refactoring test code, during that work I found a couple of bugs in the validator that are addressed in [this commit](https://github.com/openstax/raise-mbtools/commit/653984e3ba6d4dccc07d022551416a37b872be3c) (see corresponding commit message for more details)
* Due to :point_up: and in general what I think is a need to make sure we're catching issues WW introduces as early as possible, I made a minor change to the validator in [this commit](https://github.com/openstax/raise-mbtools/commit/79427413f174ea28a38d47e6703527d1568854d1) to include question bank data by default but support an opt out flag since processing the entire question bank has a non-trivial performance impact (~10s vs <300ms on my machine) 
* The actual test code refactoring is based on some new fixtures which allow developers to specify and generate test case specific mbz trees. This allows for isolation across test cases as well as extensibility if  / when we need to model more of the schema. For the most part I tried to rewrite existing tests using the new fixtures. However, It was a bit difficult to follow / directly map the existing validation test cases into this new structure, so instead I opted to write new tests that addressed specific facets of the implementation. I checked code coverage to be sure the new tests provide complete coverage of the corresponding code in `models.py`, but as part of the review we should make sure there aren't any additional test cases that should be written (e.g. that I didn't accidentally leave out a scenario that was embedded within the static test data in the version of things prior to refactoring)