### PR TITLE
Add ignore filter to resource upload script

### DIFF
--- a/mbtools/copy_resources_s3.py
+++ b/mbtools/copy_resources_s3.py
@@ -9,6 +9,8 @@ import botocore
 from pathlib import Path
 from csv import writer
 
+IGNORED_FILES = [".DS_Store"]
+
 
 def upload_resources(resource_dir, metadata_file, bucket, s3_dir, csv_file):
     """Uploads resources to s3 if they dont already exist there"""
@@ -50,7 +52,12 @@ def new_resource_hashes(resource_dir):
     """Generates sha1 hashes for all the resources in a local directory"""
     sha1_map = {}
     buff_size = io.DEFAULT_BUFFER_SIZE
-    for filename in os.listdir(resource_dir):
+    resource_files = filter(
+        lambda x: x not in IGNORED_FILES,
+        os.listdir(resource_dir)
+    )
+
+    for filename in resource_files:
 
         sha1 = hashlib.sha1()
         full_path = os.path.join(resource_dir, filename)

--- a/tests/test_resource_upload.py
+++ b/tests/test_resource_upload.py
@@ -69,6 +69,8 @@ def practice_filesystem(tmp_path):
         json.dump(f2_data, f)
     with open(str(tmp_path / f3), 'w') as f:
         json.dump(f3_data, f)
+    with open(f"{tmp_path}/{test_dir}/.DS_Store", "w") as f:
+        f.write(".DS_Store file")
 
     (tmp_path / 'metadata').mkdir()
     with open(str(tmp_path / metadata_file), 'w') as f:


### PR DESCRIPTION
This change adds an ignore filter which, for now, only includes the
.DS_Store filename.