### PR TITLE
Add validator exceptions for URL prefixes / values

### DIFF
--- a/mbtools/fetch_im_resources.py
+++ b/mbtools/fetch_im_resources.py
@@ -24,7 +24,7 @@ def fetch_im_resources(content_dir, output_dir, mode):
             resource_urls.extend(
                 find_references_containing(elem.etree_fragments[0], IM_PREFIX)
             )
-    elif(mode == 'html'):
+    elif (mode == 'html'):
         for item in content_dir.iterdir():
             with open(item, 'r') as f:
                 data = f.read()

--- a/mbtools/generate_mbz_toc.py
+++ b/mbtools/generate_mbz_toc.py
@@ -36,7 +36,7 @@ def create_toc(mbz_path, md_filepath):
                         id2page[page.id] = page
                         if (page.prev == "0"):
                             current_page = page
-                    while(True):
+                    while (True):
                         html_elem = current_page.html_element()
                         uuid = html_elem.get_attribute_values(
                             "data-content-id")[0]

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -136,7 +136,7 @@ def find_tag_violations(html_elements):
         for hit in hits:
             link = hit.attrib['src']
             if len([prefix for prefix in VALID_IFRAME_PREFIXES
-                    if(prefix in link)]) == 0:
+                    if (prefix in link)]) == 0:
                 violations.append(Violation(IFRAME_VIOLATION,
                                             elem.location,
                                             link))
@@ -145,7 +145,7 @@ def find_tag_violations(html_elements):
             if "href" in hit.attrib.keys():
                 link = hit.attrib["href"]
                 prefix_match = [
-                    prefix for prefix in VALID_HREF_PREFIXES if(prefix in link)
+                    pfx for pfx in VALID_HREF_PREFIXES if (pfx in link)
                 ]
                 if len(prefix_match) == 0 and link not in VALID_HREF_VALUES:
                     violations.append(Violation(HREF_VIOLATION,
@@ -159,7 +159,7 @@ def find_source_violations(html_elements):
     for elem in html_elements:
         links = elem.get_attribute_values('src', exception='iframe')
         for link in links:
-            if len([prefix for prefix in VALID_PREFIXES if(prefix in link)]) \
+            if len([prefix for prefix in VALID_PREFIXES if (prefix in link)]) \
                     > 0:    # check if link contains a valid prefix
                 continue
             elif "@@PLUGINFILE@@" in link:

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -15,22 +15,34 @@ HREF_VIOLATION = "ERROR: Uses invalid 'href' value in <a> tag"
 UNNESTED_VIOLATION = "ERROR: Contains content not nested in HTML Element"
 NESTED_IB_VIOLATION = "ERROR: Interactive block nested within HTML"
 
-VALID_PREFIXES = ["https://s3.amazonaws.com/im-ims-export/",
-                  "https://k12.openstax.org/contents/raise",
-                  "https://www.youtube.com/",
-                  "https://digitalpromise.org"]
+VALID_PREFIXES = [
+    "https://s3.amazonaws.com/im-ims-export/",
+    "https://k12.openstax.org/contents/raise",
+    "https://www.youtube.com/",
+    "https://digitalpromise.org"
+]
 
 VALID_IFRAME_PREFIXES = ["https://www.youtube.com"]
 
-VALID_HREF_PREFIXES = ["https://k12.openstax.org/contents/raise",
-                       "https://vimeo.com",
-                       "https://player.vimeo.com",
-                       "https://youtube.com",
-                       "https://www.youtube.com",
-                       "https://youtu.be",
-                       "https://characterlab.org/",
-                       "https://digitalpromise.org",
-                       "https://www.doe.virginia.gov"]
+VALID_HREF_PREFIXES = [
+    "https://k12.openstax.org/contents/raise",
+    "https://vimeo.com",
+    "https://player.vimeo.com",
+    "https://youtube.com",
+    "https://www.youtube.com",
+    "https://youtu.be",
+    "https://characterlab.org/",
+    "https://digitalpromise.org",
+    "https://www.doe.virginia.gov",
+    "https://tea.texas.gov",
+    "https://www.sfusdmath.org"
+]
+
+VALID_HREF_VALUES = [
+    "https://illustrativemathematics.org/",
+    "https://openstax.org/",
+    "https://www.wisewire.com/"
+]
 
 VALID_STYLES = []
 
@@ -132,8 +144,10 @@ def find_tag_violations(html_elements):
         for hit in hits:
             if "href" in hit.attrib.keys():
                 link = hit.attrib["href"]
-                if len([prefix for prefix in VALID_HREF_PREFIXES
-                        if(prefix in link)]) == 0:
+                prefix_match = [
+                    prefix for prefix in VALID_HREF_PREFIXES if(prefix in link)
+                ]
+                if len(prefix_match) == 0 and link not in VALID_HREF_VALUES:
                     violations.append(Violation(HREF_VIOLATION,
                                                 elem.location,
                                                 link))

--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -22,7 +22,10 @@ VALID_PREFIXES = [
     "https://digitalpromise.org"
 ]
 
-VALID_IFRAME_PREFIXES = ["https://www.youtube.com"]
+VALID_IFRAME_PREFIXES = [
+    "https://www.youtube.com",
+    "https://player.vimeo.com"
+]
 
 VALID_HREF_PREFIXES = [
     "https://k12.openstax.org/contents/raise",

--- a/tests/test_extract_html_content.py
+++ b/tests/test_extract_html_content.py
@@ -205,9 +205,9 @@ def test_ignore_extracted_content(tmp_path, page_builder, mbz_builder):
     assert len(html_files_inmbz_first_run) == len(html_files_inmbz_second_run)
 
     # First run of extract content should return 3 files
-    assert(len(html_files_list_first_run) == 3)
+    assert (len(html_files_list_first_run) == 3)
     # Second run of the extract content should not return files.
-    assert(len(html_files_list_second_run) == 0)
+    assert (len(html_files_list_second_run) == 0)
 
 
 def test_main_no_filter(

--- a/tests/test_fetch_im_resources.py
+++ b/tests/test_fetch_im_resources.py
@@ -126,7 +126,7 @@ def test_fetch_im_resources_main(
 
     fetch_im_resources.main()
 
-    assert(len(os.listdir(output_path)) == 4)
+    assert (len(os.listdir(output_path)) == 4)
     for filename in os.listdir(output_path):
         f = os.path.join(output_path, filename)
         with open(f, 'r') as file:

--- a/tests/test_html_to_json.py
+++ b/tests/test_html_to_json.py
@@ -43,8 +43,8 @@ def get_json_content(file_path):
 
 def test_json_file_created(file_path):
     html_to_json(f'{file_path}/html_directory', f'{file_path}/json_directory')
-    assert("fragment.json" in os.listdir(f'{file_path}/json_directory'))
-    assert("fragment2.json" in os.listdir(f'{file_path}/json_directory'))
+    assert ("fragment.json" in os.listdir(f'{file_path}/json_directory'))
+    assert ("fragment2.json" in os.listdir(f'{file_path}/json_directory'))
 
 
 def test_html_in_json(file_path):

--- a/tests/test_resource_upload.py
+++ b/tests/test_resource_upload.py
@@ -104,9 +104,9 @@ def test_existing_metadata_hashes(practice_filesystem):
 
 
 def test_new_resource_hashes(practice_filesystem):
-    assert(len(copy_resources_s3.new_resource_hashes(
+    assert (len(copy_resources_s3.new_resource_hashes(
                practice_filesystem[test_dir])[0]) == 3
-           )
+            )
     with pytest.raises(FileNotFoundError):
         copy_resources_s3.new_resource_hashes("")
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -134,12 +134,13 @@ def test_style_violation():
 def test_href_violation():
     location = "here"
     parent = etree.fromstring("<content></content>")
-    parent.text = '<a href="something">html</a>'
+    parent.text = '<a href="https://openstax.org/apps/archive">html</a>'
+    parent.text += '<a href="https://openstax.org/">html</a>'
     elem = MoodleHtmlElement(parent, location)
     style_violations = validate_mbz_html.find_tag_violations([elem])
     assert len(style_violations) == 1
     assert style_violations[0].issue == validate_mbz_html.HREF_VIOLATION
-    assert style_violations[0].link == "something"
+    assert style_violations[0].link == "https://openstax.org/apps/archive"
     assert style_violations[0].location == "here"
 
 


### PR DESCRIPTION
This change is to help support content CI jobs by removing any false
positive errors which were previously ignored via human review.