### PR TITLE
Fix bugs in commands so they work with html directories

### DIFF
--- a/mbtools/fetch_im_resources.py
+++ b/mbtools/fetch_im_resources.py
@@ -25,7 +25,7 @@ def fetch_im_resources(content_dir, output_dir, mode):
                 find_references_containing(elem.etree_fragments[0], IM_PREFIX)
             )
     elif (mode == 'html'):
-        for item in content_dir.iterdir():
+        for item in content_dir.rglob('*.html'):
             with open(item, 'r') as f:
                 data = f.read()
                 tree = html.fragments_fromstring(data)[0]

--- a/mbtools/fix_html.py
+++ b/mbtools/fix_html.py
@@ -8,8 +8,8 @@ def fix_html(html_directory):
     block_tags = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
     soup = None
 
-    for html_file in Path(html_directory).iterdir():
-        with open(f"{html_directory}/{html_file.name}") as f:
+    for html_file in Path(html_directory).rglob('*.html'):
+        with open(html_file) as f:
             soup = BeautifulSoup(f.read(), 'html.parser')
             for tags in [inline_tags, block_tags]:
                 for elem in soup.find_all(tags):
@@ -17,7 +17,7 @@ def fix_html(html_directory):
                          and len(elem.find_all()) == 0:
                         elem.extract()
 
-        with open(f"{html_directory}/{html_file.name}", 'w') as f:
+        with open(html_file, 'w') as f:
             f.write(soup.encode(formatter="html5").decode('utf-8'))
 
 

--- a/mbtools/replace_im_links.py
+++ b/mbtools/replace_im_links.py
@@ -64,7 +64,7 @@ def replace_im_links(content_path, media_path, s3_prefix, mode):
                 utils.write_etree(act.activity_filename, act.etree)
         utils.write_etree(q_bank.questionbank_path, q_bank.etree)
     elif (mode == 'html'):
-        for item in content_path.iterdir():
+        for item in content_path.rglob('*.html'):
             num_changes = 0
             with open(item, 'r') as f:
                 data = f.read()

--- a/tests/test_fetch_im_resources.py
+++ b/tests/test_fetch_im_resources.py
@@ -235,6 +235,9 @@ def test_fetch_im_resource_extracted(
     lesson1_page2_content = f'''
     <div><p>Lesson 1 Page 1</p>
     <img src="{im_resource2}"></img></div>'''
+    lesson1_page2_variant_content = f'''
+    <div><p>Lesson 1 Page 1 Variant</p>
+    <img src="{im_resource2}"></img></div>'''
 
     extracted_path = tmp_path / "extracted"
     extracted_path.mkdir(parents=True, exist_ok=True)
@@ -242,6 +245,10 @@ def test_fetch_im_resource_extracted(
     extracted_filename.write_text(lesson1_page1_content)
     extracted_filename2 = extracted_path / "lesson1page2.html"
     extracted_filename2.write_text(lesson1_page2_content)
+    extracted_filename2_variant_dir = extracted_path / "lesson1page2"
+    extracted_filename2_variant_dir.mkdir()
+    extracted_filename2_variant = extracted_filename2_variant_dir / "foo.html"
+    extracted_filename2_variant.write_text(lesson1_page2_variant_content)
 
     output_path = tmp_path / "im_resources"
     mocker.patch(

--- a/tests/test_fix_html.py
+++ b/tests/test_fix_html.py
@@ -30,16 +30,18 @@ output_html = (
 @pytest.fixture
 def file_path(tmp_path):
 
-    (tmp_path / 'html_directory').mkdir()
-    (tmp_path / 'html_directory' / "htmlfile.html").write_text(HTML)
+    html_directory = tmp_path / 'html_directory'
 
-    return tmp_path
+    html_directory.mkdir()
+    (html_directory / "htmlfile.html").write_text(HTML)
+
+    return html_directory
 
 
-def test_json_file_created(file_path):
-    fix_html(f'{file_path}/html_directory')
+def test_remove_empty_elems(file_path):
+    fix_html(str(file_path))
     content = ''
-    with open(f'{file_path}/html_directory/htmlfile.html') as f:
+    with open(f'{file_path}/htmlfile.html') as f:
         content = f.read()
 
     assert (content == output_html)
@@ -49,9 +51,25 @@ def test_main(file_path, mocker):
     # Test for main function called by the CLI.
     mocker.patch(
         "sys.argv",
-        ["", f"{file_path}/html_directory"]
+        ["", str(file_path)]
     )
     main()
-    with open(f"{file_path}/html_directory/htmlfile.html", 'r') as f:
+    with open(f"{file_path}/htmlfile.html", 'r') as f:
         file = f.read()
         assert ('<h2></h2>' not in file)
+
+
+def test_directories(file_path):
+    (file_path / 'htmldir').mkdir()
+    (file_path / 'htmldir' / 'content.html').write_text(HTML)
+    fix_html(str(file_path))
+
+    with open(f'{file_path}/htmlfile.html') as f:
+        content = f.read()
+
+    assert (content == output_html)
+
+    with open(f'{file_path}/htmldir/content.html') as f:
+        content = f.read()
+
+    assert (content == output_html)

--- a/tests/test_replace_im_links.py
+++ b/tests/test_replace_im_links.py
@@ -286,6 +286,9 @@ def test_replace_im_resource_extracted(
     lesson1_page2_content = f'''
     <div><p>Lesson 1 Page 1</p>
     <img src="{im_resource2}"></img></div>'''
+    lesson1_page2_variant_content = f'''
+    <div><p>Lesson 1 Page 1 Variant</p>
+    <img src="{im_resource2}"></img></div>'''
 
     extracted_path = tmp_path / "extracted"
     extracted_path.mkdir(parents=True, exist_ok=True)
@@ -293,6 +296,10 @@ def test_replace_im_resource_extracted(
     extracted_filename.write_text(lesson1_page1_content)
     extracted_filename2 = extracted_path / "lesson1page2.html"
     extracted_filename2.write_text(lesson1_page2_content)
+    extracted_filename2_variant_dir = extracted_path / "lesson1page2"
+    extracted_filename2_variant_dir.mkdir()
+    extracted_filename2_variant = extracted_filename2_variant_dir / "foo.html"
+    extracted_filename2_variant.write_text(lesson1_page2_variant_content)
 
     new_prefix = "k12"
     mocker.patch(
@@ -301,16 +308,15 @@ def test_replace_im_resource_extracted(
     )
     replace_im_links.main()
 
-    assert (len(os.listdir(extracted_path)) == 2)
+    assert (len(list(extracted_path.rglob("*.html"))) == 3)
     resources = []
-    for filename in os.listdir(extracted_path):
-        f = os.path.join(extracted_path, filename)
-        with open(f, 'r') as file:
+    for filename in extracted_path.rglob("*.html"):
+        with open(filename, 'r') as file:
             data = file.read()
             for elem in html.fragments_fromstring(
                         data)[0].xpath('//*[@src]'):
                 resources.append(elem.attrib['src'])
-    assert len(resources) == 2
+    assert len(resources) == 3
     for r in resources:
         assert new_prefix in r
 


### PR DESCRIPTION
This PR is to fix a bug I hit when importing new content where:

* `fix-html` otherwise fails with `IsADirectoryError: [Errno 21] Is a directory` due to the existence of html variants in the repo
* `fetch-im-resources` otherwise fails with `IsADirectoryError: [Errno 21] Is a directory` due to the existence of html variants in the repo.
* `replace-im-links` otherwise fails with `IsADirectoryError: [Errno 21] Is a directory` due to the existence of html variants in the repo.