### PR TITLE
Fix xpath query for qbank questions property

### DIFF
--- a/mbtools/models.py
+++ b/mbtools/models.py
@@ -81,7 +81,11 @@ class MoodleQuestionBank:
 
     @property
     def questions(self):
-        return [MoodleQuestion(q) for q in self.etree.xpath("//question")]
+        return [
+            MoodleQuestion(q) for q in self.etree.xpath(
+                "//questions/question"
+            )
+        ]
 
     @property
     def latest_questions(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -115,7 +115,9 @@ def test_question_answertext_filter(tmp_path):
 
     question_bank = MoodleQuestionBank(tmp_path)
     question_bank_html = []
-    for question in question_bank.questions:
+    qbank_questions = question_bank.questions
+    assert len(qbank_questions) == 1
+    for question in qbank_questions:
         question_bank_html.extend(question.html_elements())
 
     assert len(question_bank_html) == 0
@@ -145,7 +147,9 @@ def test_question_text_filter(tmp_path):
 
     question_bank = MoodleQuestionBank(tmp_path)
     question_bank_html = []
-    for question in question_bank.questions:
+    qbank_questions = question_bank.questions
+    assert len(qbank_questions) == 1
+    for question in qbank_questions:
         question_bank_html.extend(question.html_elements())
 
     assert len(question_bank_html) == 0


### PR DESCRIPTION
The previous xpath was catching things like `<question>541</question>` inside of question data which subsequently caused errors during creation of MoodleQuestion objects. This constrains the query to strictly look at direct children of `<questions>` when searching for all qbank questions.