### PR TITLE
Remove IM URL from valid prefix list

### DIFF
--- a/mbtools/validate_mbz_html.py
+++ b/mbtools/validate_mbz_html.py
@@ -21,7 +21,6 @@ DUPLICATE_QBANK_UUID_VIOLATION = "ERROR: Duplicate question bank UUID"
 INVALID_QBANK_UUID_VIOLATION = "ERROR: Invalid question bank UUID"
 
 VALID_PREFIXES = [
-    "https://s3.amazonaws.com/im-ims-export/",
     "https://k12.openstax.org/contents/raise",
     "https://www.youtube.com/",
     "https://digitalpromise.org"


### PR DESCRIPTION
We allowed IM links during v1 development since we were converting those to hosted links as part of the import process. Now that v1 is complete, we should disallow the prefix since there are no valid scenarios where we expect them to arise.